### PR TITLE
Configurable Prometheus endpoint via Corefile variable

### DIFF
--- a/cmd/node-cache/app/cache_app.go
+++ b/cmd/node-cache/app/cache_app.go
@@ -36,22 +36,23 @@ var (
 
 // ConfigParams lists the configuration options that can be provided to node-cache
 type ConfigParams struct {
-	LocalIPStr           string        // comma separated listen ips for the local cache agent
-	LocalIPs             []net.IP      // parsed ip addresses for the local cache agent to listen for dns requests
-	LocalPort            string        // port to listen for dns requests
-	MetricsListenAddress string        // address to serve metrics on
-	SetupInterface       bool          // Indicates whether to setup network interface
-	InterfaceName        string        // Name of the interface to be created
-	Interval             time.Duration // specifies how often to run iptables rules check
-	Pidfile              string        // Path to the coredns server pidfile
-	BaseCoreFile         string        // Path to the template config file for node-cache
-	CoreFile             string        // Path to config file used by node-cache
-	KubednsCMPath        string        // Directory where kube-dns configmap will be mounted
-	UpstreamSvcName      string        // Name of the service whose clusterIP is the upstream for node-cache for cluster domain
-	HealthPort           string        // port for the healthcheck
-	SetupIptables        bool
-	SkipTeardown         bool // Indicates whether the iptables rules and interface should be torn down
-	ReloadWithSignal     bool // Indicates config reload should be triggered with SIGUSR1, rather than expecting CoreDNS's reload plugin
+	LocalIPStr              string        // comma separated listen ips for the local cache agent
+	LocalIPs                []net.IP      // parsed ip addresses for the local cache agent to listen for dns requests
+	LocalPort               string        // port to listen for dns requests
+	MetricsListenAddress    string        // address to serve metrics on
+	PrometheusListenAddress string        // address to serve Prometheus metrics on
+	SetupInterface          bool          // Indicates whether to setup network interface
+	InterfaceName           string        // Name of the interface to be created
+	Interval                time.Duration // specifies how often to run iptables rules check
+	Pidfile                 string        // Path to the coredns server pidfile
+	BaseCoreFile            string        // Path to the template config file for node-cache
+	CoreFile                string        // Path to config file used by node-cache
+	KubednsCMPath           string        // Directory where kube-dns configmap will be mounted
+	UpstreamSvcName         string        // Name of the service whose clusterIP is the upstream for node-cache for cluster domain
+	HealthPort              string        // port for the healthcheck
+	SetupIptables           bool
+	SkipTeardown            bool // Indicates whether the iptables rules and interface should be torn down
+	ReloadWithSignal        bool // Indicates config reload should be triggered with SIGUSR1, rather than expecting CoreDNS's reload plugin
 }
 
 type iptablesRule struct {

--- a/cmd/node-cache/app/cache_app_test.go
+++ b/cmd/node-cache/app/cache_app_test.go
@@ -39,7 +39,7 @@ cluster.local:53 {
     forward . __PILLAR__CLUSTER__DNS__ {
             force_tcp
     }
-    prometheus :9253
+    prometheus __PROMETHEUS__ENDPOINT__
     }
 .:53 {
     errors
@@ -50,7 +50,7 @@ cluster.local:53 {
     forward . __PILLAR__UPSTREAM__SERVERS__ {
             force_tcp
     }
-    prometheus :9253
+    prometheus __PROMETHEUS__ENDPOINT__
     }
 `
 	templateCoreFileName   = "testCoreFile.base"
@@ -139,12 +139,13 @@ func TestUpdateCoreFile(t *testing.T) {
 	envName := strings.ToUpper(strings.Replace(UpstreamClusterDNS, "-", "_", -1)) + "_SERVICE_HOST"
 	os.Setenv(envName, "9.10.11.12")
 	c, err := NewCacheApp(&ConfigParams{LocalIPStr: "169.254.20.10,10.0.0.10",
-		LocalPort:       "53",
-		BaseCoreFile:    filepath.Join(baseDir, templateCoreFileName),
-		CoreFile:        filepath.Join(baseDir, coreFileName),
-		KubednsCMPath:   filepath.Join(baseDir, cmDirName),
-		UpstreamSvcName: UpstreamClusterDNS,
-		SetupIptables:   false,
+		LocalPort:               "53",
+		BaseCoreFile:            filepath.Join(baseDir, templateCoreFileName),
+		CoreFile:                filepath.Join(baseDir, coreFileName),
+		KubednsCMPath:           filepath.Join(baseDir, cmDirName),
+		UpstreamSvcName:         UpstreamClusterDNS,
+		SetupIptables:           false,
+		PrometheusListenAddress: ":9253",
 	})
 	if err != nil {
 		t.Fatalf("Failed to obtain CacheApp instance, err %v", err)
@@ -156,7 +157,8 @@ func TestUpdateCoreFile(t *testing.T) {
 	r := strings.NewReplacer(LocalListenIPsVar, listenIPs,
 		UpstreamClusterDNSVar, "9.10.11.12",
 		UpstreamServerVar, "/etc/resolv.conf",
-		LocalDNSServerVar, "")
+		LocalDNSServerVar, "",
+		PrometheusEndpointVar, ":9253")
 	expectedContents := r.Replace(templateCoreFileContents)
 	if out, diff := compareFileContents(c.params.CoreFile, expectedContents, t); diff != 0 {
 		t.Errorf("Expected contents '%s', Got '%s'", expectedContents, out)
@@ -187,7 +189,8 @@ func TestUpdateCoreFile(t *testing.T) {
 	r = strings.NewReplacer(LocalListenIPsVar, listenIPs,
 		UpstreamClusterDNSVar, "9.10.11.12",
 		LocalDNSServerVar, "",
-		upstreamTCPBlock, upstreamUDP)
+		upstreamTCPBlock, upstreamUDP,
+		PrometheusEndpointVar, ":9253")
 	expectedContents = r.Replace(newTemplateContents)
 	expectedStubStr := getStubDomainStr(customConfig.StubDomains, &stubDomainInfo{Port: c.params.LocalPort, CacheTTL: defaultTTL,
 		LocalIP: strings.Replace(c.params.LocalIPStr, ",", " ", -1)})
@@ -211,12 +214,13 @@ func TestUpdateIPv6CoreFile(t *testing.T) {
 	envName := strings.ToUpper(strings.Replace(UpstreamClusterDNS, "-", "_", -1)) + "_SERVICE_HOST"
 	os.Setenv(envName, "2001:db8::1")
 	c, err := NewCacheApp(&ConfigParams{LocalIPStr: "fe80:169:254::1,fd00:1:2:3::5",
-		LocalPort:       "53",
-		BaseCoreFile:    filepath.Join(baseDir, templateCoreFileName),
-		CoreFile:        filepath.Join(baseDir, coreFileName),
-		KubednsCMPath:   filepath.Join(baseDir, cmDirName),
-		UpstreamSvcName: UpstreamClusterDNS,
-		SetupIptables:   false,
+		LocalPort:               "53",
+		BaseCoreFile:            filepath.Join(baseDir, templateCoreFileName),
+		CoreFile:                filepath.Join(baseDir, coreFileName),
+		KubednsCMPath:           filepath.Join(baseDir, cmDirName),
+		UpstreamSvcName:         UpstreamClusterDNS,
+		SetupIptables:           false,
+		PrometheusListenAddress: ":9253",
 	})
 	if err != nil {
 		t.Fatalf("Failed to obtain CacheApp instance, err %v", err)
@@ -228,7 +232,8 @@ func TestUpdateIPv6CoreFile(t *testing.T) {
 	r := strings.NewReplacer(LocalListenIPsVar, listenIPs,
 		UpstreamClusterDNSVar, "2001:db8::1",
 		UpstreamServerVar, "/etc/resolv.conf",
-		LocalDNSServerVar, "")
+		LocalDNSServerVar, "",
+		PrometheusEndpointVar, ":9253")
 	expectedContents := r.Replace(templateCoreFileContents)
 	if out, diff := compareFileContents(c.params.CoreFile, expectedContents, t); diff != 0 {
 		t.Errorf("Expected contents '%s', Got '%s'", expectedContents, out)
@@ -259,7 +264,8 @@ func TestUpdateIPv6CoreFile(t *testing.T) {
 	r = strings.NewReplacer(LocalListenIPsVar, listenIPs,
 		UpstreamClusterDNSVar, "2001:db8::1",
 		LocalDNSServerVar, "",
-		upstreamTCPBlock, upstreamUDP)
+		upstreamTCPBlock, upstreamUDP,
+		PrometheusEndpointVar, ":9253")
 	expectedContents = r.Replace(newTemplateContents)
 	expectedStubStr := getStubDomainStr(customConfig.StubDomains, &stubDomainInfo{Port: c.params.LocalPort, CacheTTL: defaultTTL,
 		LocalIP: strings.Replace(c.params.LocalIPStr, ",", " ", -1)})

--- a/cmd/node-cache/app/configmap.go
+++ b/cmd/node-cache/app/configmap.go
@@ -50,6 +50,8 @@ const (
 	LocalListenIPsVar       = "__PILLAR__LOCAL__DNS__"
 	LocalDNSServerVar       = "__PILLAR__DNS__SERVER__"
 	DefaultKubednsCMPath    = "/etc/kube-dns"
+
+	PrometheusEndpointVar = "__PROMETHEUS__ENDPOINT__"
 )
 
 // stubDomainInfo contains all the parameters needed to compute
@@ -121,6 +123,11 @@ func (c *CacheApp) updateCorefile(dnsConfig *config.Config) {
 	// variables are left unsubstituted.
 	if bytes.Contains(baseConfig, []byte(LocalDNSServerVar)) {
 		baseConfig = bytes.Replace(baseConfig, []byte(LocalDNSServerVar), []byte(""), -1)
+	}
+
+	// If the template Corefile has the Prometheus plugin, replace the bind address with the one specified in the parameters. Otherwise, do nothing since there is no Prometheus plugin to update.
+	if bytes.Contains(baseConfig, []byte(PrometheusEndpointVar)) {
+		baseConfig = bytes.Replace(baseConfig, []byte(PrometheusEndpointVar), []byte(c.params.PrometheusListenAddress), -1)
 	}
 
 	newConfig := bytes.Buffer{}

--- a/cmd/node-cache/main.go
+++ b/cmd/node-cache/main.go
@@ -84,6 +84,7 @@ func parseAndValidateFlags() (*app.ConfigParams, error) {
 	flag.StringVar(&params.InterfaceName, "interfacename", "nodelocaldns", "name of the interface to be created")
 	flag.DurationVar(&params.Interval, "syncinterval", 60, "interval(in seconds) to check for iptables rules")
 	flag.StringVar(&params.MetricsListenAddress, "metrics-listen-address", "0.0.0.0:9353", "address to serve metrics on")
+	flag.StringVar(&params.PrometheusListenAddress, "prometheus-listen-address", ":9253", "address to serve Prometheus metrics on")
 	flag.BoolVar(&params.SetupIptables, "setupiptables", true, "indicates whether iptables rules should be setup")
 	flag.StringVar(&params.BaseCoreFile, "basecorefile", "/etc/coredns/Corefile.base", "Path to the template Corefile for node-cache")
 	flag.StringVar(&params.CoreFile, "corefile", "/etc/Corefile", "Path to the Corefile to be used by node-cache")


### PR DESCRIPTION
Previously, the Prometheus metrics endpoint in the node-cache Corefile was hardcoded to listen on all interfaces (e.g. "prometheus :9253"). This means the metrics port is exposed on every network interface of the node, which is undesirable in security-sensitive environments where metrics scraping should be restricted to a specific network or IP address.

This change introduces a new Corefile template variable __PILLAR__PROMETHEUS__ENDPOINT__ that is substituted at runtime with the value provided via the new command-line argument `prometheus-listen-address` which defaults to ":9253". This allows operators to control which address the Prometheus endpoint binds to.

If the variable is not present in the Corefile, the behavior is unchanged.

Fixes #15