### PR TITLE
Add optional TLS support to metrics endpoint

### DIFF
--- a/cmd/node-cache/app/cache_app.go
+++ b/cmd/node-cache/app/cache_app.go
@@ -51,8 +51,9 @@ type ConfigParams struct {
 	UpstreamSvcName         string        // Name of the service whose clusterIP is the upstream for node-cache for cluster domain
 	HealthPort              string        // port for the healthcheck
 	SetupIptables           bool
-	SkipTeardown            bool // Indicates whether the iptables rules and interface should be torn down
-	ReloadWithSignal        bool // Indicates config reload should be triggered with SIGUSR1, rather than expecting CoreDNS's reload plugin
+	SkipTeardown            bool      // Indicates whether the iptables rules and interface should be torn down
+	ReloadWithSignal        bool      // Indicates config reload should be triggered with SIGUSR1, rather than expecting CoreDNS's reload plugin
+	TlsConfig               TlsConfig // Config for the metrics endpoint
 }
 
 type iptablesRule struct {
@@ -85,7 +86,10 @@ func (c *CacheApp) Init() {
 	if c.params.SetupIptables {
 		c.initIptables()
 	}
-	initMetrics(c.params.MetricsListenAddress)
+	met := NewMetrics(c.params.MetricsListenAddress, &c.params.TlsConfig)
+	if err := met.StartServer(); err != nil {
+		clog.Errorf("Failed to serve metrics with error \"%s\"", err)
+	}
 	// Write the config file from template.
 	// this is required in case there is no or erroneous kube-dns configpath specified.
 	c.updateCorefile(&config.Config{})

--- a/cmd/node-cache/app/metrics.go
+++ b/cmd/node-cache/app/metrics.go
@@ -14,14 +14,38 @@ limitations under the License.
 package app
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
+	"os"
+	"slices"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/reuseport"
+
 	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/exporter-toolkit/web"
 )
+
+var (
+	log = clog.NewWithPlugin("prometheus")
+
+	// ListenAddr is assigned the address of the prometheus listener. Its use
+	// is mainly in tests where we listen on "localhost:0" and need to retrieve
+	// the actual address.
+	ListenAddr string
+)
+
+// shutdownTimeout is the maximum amount of time the metrics plugin will wait
+// before erroring when it tries to close the metrics server
+const shutdownTimeout time.Duration = time.Second * 5
 
 var setupErrCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Namespace: plugin.Namespace,
@@ -30,12 +54,239 @@ var setupErrCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Help:      "The number of errors during periodic network setup for node-cache",
 }, []string{"errortype"})
 
-func initMetrics(ipport string) {
-	if err := serveMetrics(ipport); err != nil {
-		clog.Errorf("Failed to start metrics handler: %s", err)
-		return
+// startupListener wraps a net.Listener to detect when Accept() is first called
+type startupListener struct {
+	net.Listener
+	readyOnce sync.Once
+	ready     chan struct{}
+}
+
+func newStartupListener(l net.Listener) *startupListener {
+	return &startupListener{
+		Listener: l,
+		ready:    make(chan struct{}),
 	}
+}
+
+func (sl *startupListener) Accept() (net.Conn, error) {
+	// Signal ready on first Accept() call (server is running)
+	sl.readyOnce.Do(func() {
+		close(sl.ready)
+	})
+	return sl.Listener.Accept()
+}
+
+func (sl *startupListener) Ready() <-chan struct{} {
+	return sl.ready
+}
+
+// Metrics holds the prometheus configuration. The metrics' path is fixed to be /metrics .
+type Metrics struct {
+	Next plugin.Handler
+	Addr string
+	Reg  *prometheus.Registry
+
+	ln      net.Listener
+	lnSetup bool
+
+	mux *http.ServeMux
+	srv *http.Server
+
+	tlsConfig *TlsConfig
+}
+
+// TlsConfig is the TLS configuration for Metrics
+type TlsConfig struct {
+	// Enabled controls whether TLS is active
+	// Optional: Defaults to true when tls block is present
+	Enabled bool
+
+	// CertFile is the path to the server's certificate file in PEM format
+	// Required when TLS is enabled
+	CertFile string
+
+	// KeyFile is the path to the server's private key file in PEM format
+	// Required when TLS is enabled
+	KeyFile string
+
+	// ClientCAFile is the path to the CA certificate file for client verification
+	// Optional: Only needed for client authentication
+	// Default: No client verification
+	// Can contain multiple CA certificates in a single PEM file
+	ClientCAFile string
+
+	// MinVersion is the minimum TLS version to accept
+	// Optional: Defaults to tls.VersionTLS13
+	// Possible values: tls.VersionTLS10 through tls.VersionTLS13
+	MinVersion string
+
+	// ClientAuthType controls how client certificates are handled
+	// Optional: Defaults to "RequestClientCert" (strictest)
+	// Possible values:
+	//   - "RequestClientCert"
+	//   - "RequireAnyClientCert"
+	//   - "VerifyClientCertIfGiven"
+	//   - "RequireAndVerifyClientCert"
+	//   - "NoClientCert"
+	ClientAuthType string
+}
+
+// NewMetrics returns a new instance of Metrics with the given address.
+func NewMetrics(addr string, cfg *TlsConfig) *Metrics {
+	met := &Metrics{
+		Addr:      addr,
+		Reg:       prometheus.DefaultRegisterer.(*prometheus.Registry),
+		tlsConfig: cfg,
+	}
+
+	return met
+}
+
+// validate validates the Metrics configuration
+func (m *Metrics) validate() error {
+	if m.tlsConfig != nil && m.tlsConfig.Enabled {
+		if m.tlsConfig.CertFile == "" {
+			return fmt.Errorf("TLS enabled but no certificate file specified")
+		}
+		if m.tlsConfig.KeyFile == "" {
+			return fmt.Errorf("TLS enabled but no key file specified")
+		}
+		// Check if files exist
+		if _, err := os.Stat(m.tlsConfig.CertFile); err != nil {
+			return fmt.Errorf("certificate file not found: %s", m.tlsConfig.CertFile)
+		}
+		if _, err := os.Stat(m.tlsConfig.KeyFile); err != nil {
+			return fmt.Errorf("key file not found: %s", m.tlsConfig.KeyFile)
+		}
+		// Check that minversion is proper
+		allowedVersion := []string{"TLS10", "TLS11", "TLS12", "TLS13"}
+		if !slices.Contains(allowedVersion, m.tlsConfig.MinVersion) {
+			return fmt.Errorf("min TLS version must be one of: %s", strings.Join(allowedVersion, ", "))
+		}
+	}
+	return nil
+}
+
+// StartServer sets up the metrics on startup.
+func (m *Metrics) StartServer() error {
+	if err := m.validate(); err != nil {
+		return err
+	}
+
+	ln, err := reuseport.Listen("tcp", m.Addr)
+	if err != nil {
+		log.Errorf("Failed to start metrics listener: %s", err)
+		return err
+	}
+
+	startupListener := newStartupListener(ln)
+	m.ln = startupListener
+	m.lnSetup = true
+
+	m.mux = http.NewServeMux()
+	m.mux.Handle("/metrics", promhttp.HandlerFor(m.Reg, promhttp.HandlerOpts{}))
+
+	server := &http.Server{
+		Addr:    m.Addr,
+		Handler: m.mux,
+	}
+	m.srv = server
+
+	// Create logger for the server
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	webConfig := &web.FlagConfig{
+		WebListenAddresses: &[]string{m.Addr},
+		WebSystemdSocket:   new(bool), // false by default
+		WebConfigFile:      new(string),
+	}
+
+	tlsEnabled := m.tlsConfig != nil && m.tlsConfig.Enabled
+	if tlsEnabled {
+		configFile, err := m.getHTTPSWebConfigFile()
+		if err != nil {
+			return fmt.Errorf("failed to create WebConfigFile for HTTPS: %w", err)
+		}
+		*webConfig.WebConfigFile = configFile
+	} else {
+		// Setting WebConfigFile to empty disables TLS
+		*webConfig.WebConfigFile = ""
+	}
+
+	// Create channel to signal when server is ready
+	errChan := make(chan error, 1)
+	go func() {
+		// Try to start the server and report result if there is an error.
+		// web.Serve() never returns nil, it always returns a non-nil error and
+		// it doesn't return anything if server starts successfully.
+		// startupListener handles capturing succesful startup.
+		err := web.Serve(startupListener, m.srv, webConfig, logger)
+		if err != nil {
+			errChan <- err
+		}
+	}()
+
+	// Wait for server to be ready or error
+	select {
+	case <-startupListener.Ready():
+		// Server started successfully
+		clog.Infof("Nodecache metrics are served at %s with TLS set to %v", m.Addr, tlsEnabled)
+	case err := <-errChan:
+		clog.Errorf("Failed to start metrics server with TLS set to %v: %v", tlsEnabled, err)
+		return err
+	case <-time.After(2 * time.Second):
+		return fmt.Errorf("timeout waiting for server to start")
+	}
+
 	registerMetrics()
+	ListenAddr = ln.Addr().String() // For tests.
+	return nil
+}
+
+func (m *Metrics) getHTTPSWebConfigFile() (string, error) {
+	// Create temporary YAML config file for TLS settings
+	tmpFile, err := os.CreateTemp("", "metrics-tls-config-*.yaml")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temporary TLS config file: %w", err)
+	}
+	defer tmpFile.Close()
+
+	yamlConfig := fmt.Sprintf(`
+tls_server_config:
+  cert_file: %s
+  key_file: %s
+  client_ca_file: %s
+  client_auth_type: %s
+  min_version: %s
+`, m.tlsConfig.CertFile, m.tlsConfig.KeyFile, m.tlsConfig.ClientCAFile, m.tlsConfig.ClientAuthType, m.tlsConfig.MinVersion)
+
+	if _, err := tmpFile.WriteString(yamlConfig); err != nil {
+		return "", fmt.Errorf("failed to write TLS config to temporary file: %w", err)
+	}
+
+	return tmpFile.Name(), nil
+}
+
+func (m *Metrics) StopServer() error {
+	if !m.lnSetup {
+		return nil
+	}
+	// Shutdown the server
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	// Shutdown also closes listeners
+	if err := m.srv.Shutdown(ctx); err != nil {
+		log.Infof("Failed to stop metrics server: %s", err)
+		return err
+	}
+
+	m.lnSetup = false
+	prometheus.Unregister(setupErrCount)
+	return nil
+}
+
+func publishErrorMetric(label string) {
+	setupErrCount.WithLabelValues(label).Inc()
 }
 
 func registerMetrics() {
@@ -45,23 +296,4 @@ func registerMetrics() {
 	setupErrCount.WithLabelValues("interface_add").Add(0)
 	setupErrCount.WithLabelValues("interface_check").Add(0)
 	setupErrCount.WithLabelValues("configmap").Add(0)
-}
-
-func publishErrorMetric(label string) {
-	setupErrCount.WithLabelValues(label).Inc()
-}
-
-func serveMetrics(ipport string) error {
-	ln, err := net.Listen("tcp", ipport)
-	if err != nil {
-		return err
-	}
-
-	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
-	srv := &http.Server{Handler: mux}
-	go func() {
-		srv.Serve(ln)
-	}()
-	return nil
 }

--- a/cmd/node-cache/app/metrics_test.go
+++ b/cmd/node-cache/app/metrics_test.go
@@ -1,0 +1,330 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+)
+
+func createTestCertFiles(t *testing.T) (certFile, keyFile, caFile string, cleanup func()) {
+	// Generate CA certificate
+	caCert, caKey, err := generateCA()
+	if err != nil {
+		t.Fatalf("Failed to generate CA certificate: %v", err)
+	}
+
+	// Generate server certificate signed by CA
+	cert, key, err := generateCert(caCert, caKey)
+	if err != nil {
+		t.Fatalf("Failed to generate server certificate: %v", err)
+	}
+
+	// Write certificates to temporary files
+	certFile = writeTempFile(t, string(cert))
+	keyFile = writeTempFile(t, string(key))
+	caFile = writeTempFile(t, string(caCert))
+
+	// Return cleanup function to remove files
+	cleanup = func() {
+		os.Remove(certFile)
+		os.Remove(keyFile)
+		os.Remove(caFile)
+	}
+	return certFile, keyFile, caFile, cleanup
+}
+
+func generateCA() ([]byte, []byte, error) {
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(2023),
+		Subject: pkix.Name{
+			Organization: []string{"Test CA"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(1, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	caPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+
+	caPrivKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
+	})
+
+	return caPEM, caPrivKeyPEM, nil
+}
+
+func generateCert(caCertPEM, caKeyPEM []byte) ([]byte, []byte, error) {
+	caCertBlock, _ := pem.Decode(caCertPEM)
+	caCert, err := x509.ParseCertificate(caCertBlock.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	caKeyBlock, _ := pem.Decode(caKeyPEM)
+	caKey, err := x509.ParsePKCS1PrivateKey(caKeyBlock.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(2023),
+		Subject: pkix.Name{
+			Organization: []string{"Test Server"},
+		},
+		DNSNames:    []string{"localhost"},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().AddDate(1, 0, 0),
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, caCert, &certPrivKey.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+
+	certPrivKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(certPrivKey),
+	})
+
+	return certPEM, certPrivKeyPEM, nil
+}
+
+func loadTestClientCert(t *testing.T, certFile, keyFile string) tls.Certificate {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		t.Fatalf("Failed to load client certificate: %v", err)
+	}
+	return cert
+}
+
+func writeTempFile(t *testing.T, content string) string {
+	tmpFile, err := os.CreateTemp("", "testcert")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer tmpFile.Close()
+
+	if _, err := tmpFile.WriteString(content); err != nil {
+		t.Fatalf("Failed to write to temp file: %v", err)
+	}
+	return tmpFile.Name()
+}
+
+func TestMetricsTLS(t *testing.T) {
+	certFile, keyFile, caFile, cleanup := createTestCertFiles(t)
+	defer cleanup()
+
+	tests := []struct {
+		name        string
+		tlsConfig   *TlsConfig
+		expectError bool
+		expectHTTPS bool
+	}{
+		{
+			name:        "No TLS",
+			tlsConfig:   nil,
+			expectError: false,
+			expectHTTPS: false,
+		},
+		{
+			name: "Valid TLS",
+			tlsConfig: &TlsConfig{
+				Enabled:    true,
+				CertFile:   certFile,
+				KeyFile:    keyFile,
+				MinVersion: "TLS13",
+			},
+			expectError: false,
+			expectHTTPS: true,
+		},
+		{
+			name: "TLS with client auth",
+			tlsConfig: &TlsConfig{
+				Enabled:        true,
+				CertFile:       certFile,
+				KeyFile:        keyFile,
+				ClientCAFile:   caFile,
+				ClientAuthType: "RequireAndVerifyClientCert",
+				MinVersion:     "TLS13",
+			},
+			expectError: false,
+			expectHTTPS: true,
+		},
+		{
+			name: "Missing cert file",
+			tlsConfig: &TlsConfig{
+				Enabled:    true,
+				CertFile:   "missing.pem",
+				KeyFile:    keyFile,
+				MinVersion: "TLS13",
+			},
+			expectError: true,
+			expectHTTPS: false,
+		},
+		{
+			name: "Missing key file",
+			tlsConfig: &TlsConfig{
+				Enabled:    true,
+				CertFile:   certFile,
+				KeyFile:    "missing-key.pem",
+				MinVersion: "TLS13",
+			},
+			expectError: true,
+			expectHTTPS: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			met := NewMetrics("localhost:0", tt.tlsConfig)
+			// met.tlsConfig = tt.tlsConfig
+
+			// Start server
+			err := met.StartServer()
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Failed to start metrics handler: %s", err)
+			}
+			defer met.StopServer()
+
+			// Wait for server to be ready
+			select {
+			case <-time.After(2 * time.Second):
+				t.Fatal("timeout waiting for server to start")
+			case <-func() chan struct{} {
+				ch := make(chan struct{})
+				go func() {
+					for {
+						conn, err := net.DialTimeout("tcp", ListenAddr, 100*time.Millisecond)
+						if err == nil {
+							conn.Close()
+							close(ch)
+							return
+						}
+						time.Sleep(100 * time.Millisecond)
+					}
+				}()
+				return ch
+			}():
+			}
+
+			// Configure client
+			tlsConfig := &tls.Config{
+				InsecureSkipVerify: true,
+			}
+			if tt.tlsConfig != nil && tt.tlsConfig.ClientCAFile != "" {
+				// Load CA cert for client auth
+				caCert, err := os.ReadFile(tt.tlsConfig.ClientCAFile)
+				if err != nil {
+					t.Fatalf("Failed to read CA cert: %v", err)
+				}
+				caCertPool := x509.NewCertPool()
+				if !caCertPool.AppendCertsFromPEM(caCert) {
+					t.Fatal("Failed to parse CA cert")
+				}
+				tlsConfig.RootCAs = caCertPool
+				tlsConfig.Certificates = []tls.Certificate{loadTestClientCert(t, certFile, keyFile)}
+			}
+
+			client := &http.Client{
+				Timeout: 10 * time.Second,
+				Transport: &http.Transport{
+					TLSClientConfig: tlsConfig,
+					// Allow connection reuse
+					MaxIdleConns:        10,
+					IdleConnTimeout:     30 * time.Second,
+					DisableCompression:  true,
+					TLSHandshakeTimeout: 10 * time.Second,
+				},
+			}
+
+			// Determine protocol
+			protocol := "http"
+			if tt.expectHTTPS {
+				protocol = "https"
+			}
+
+			// Try multiple times to account for server startup time
+			var resp *http.Response
+			var err2 error
+			for i := range 10 { // Increased retry count
+				url := fmt.Sprintf("%s://%s/metrics", protocol, ListenAddr)
+				t.Logf("Attempt %d: Connecting to %s", i+1, url)
+				resp, err2 = client.Get(url)
+				if err2 == nil {
+					t.Logf("Successfully connected to metrics server")
+					break
+				}
+				t.Logf("Connection attempt failed: %v", err2)
+				time.Sleep(500 * time.Millisecond) // Increased delay between attempts
+			}
+			if err2 != nil {
+				t.Fatalf("Failed to connect to metrics server: %v", err2)
+			}
+			if resp != nil {
+				defer resp.Body.Close()
+			}
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("Expected status 200, got %d", resp.StatusCode)
+			}
+		})
+	}
+}

--- a/cmd/node-cache/main.go
+++ b/cmd/node-cache/main.go
@@ -93,6 +93,13 @@ func parseAndValidateFlags() (*app.ConfigParams, error) {
 	flag.StringVar(&params.HealthPort, "health-port", "8080", "port used by health plugin")
 	flag.BoolVar(&params.SkipTeardown, "skipteardown", false, "indicates whether iptables rules should be torn down on exit")
 	flag.BoolVar(&params.ReloadWithSignal, "reloadwithsignal", false, "use SIGUSR1 on self to reload CoreDNS")
+
+	flag.StringVar(&params.TlsConfig.CertFile, "tls-cert-file", "/etc/ssl/tls.crt", "Path to TLS certificate for HTTPS, defaults to '/etc/ssl/tls.crt'")
+	flag.StringVar(&params.TlsConfig.KeyFile, "tls-private-key-file", "/etc/ssl/tls.key", "Path to TLS private key for HTTPS, defaults to '/etc/ssl/tls.key'")
+	flag.StringVar(&params.TlsConfig.ClientAuthType, "tls-client-auth-type", "NoClientCert", "TLS client authorization type, defaults to 'NoClientCert'")
+	flag.StringVar(&params.TlsConfig.ClientCAFile, "tls-client-ca-file", "", "Path to TLS client CA file, defaults to ''")
+	flag.StringVar(&params.TlsConfig.MinVersion, "tls-min-version", "TLS13", "TLS version, defaults to TLS13")
+	flag.BoolVar(&params.TlsConfig.Enabled, "tls-enabled", false, "Enable TLS, defaults to false")
 	flag.Parse()
 
 	for _, ipstr := range strings.Split(params.LocalIPStr, ",") {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/coredns/caddy v1.1.4
 	github.com/coredns/coredns v1.14.7
 	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/exporter-toolkit v0.17.1
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.12.1
 	github.com/vishvananda/netlink v1.3.1
@@ -84,7 +85,6 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
-	github.com/prometheus/exporter-toolkit v0.17.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/puzpuzpuz/xsync/v3 v3.5.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect


### PR DESCRIPTION
This PR adds optional TLS support for the metrics server `/metrics` endpoint. TLS is configured through command line flags. Adapted the implementation for CoreDNS metrics TLS support to nodecache. The original PR here https://github.com/coredns/coredns/pull/7255

### New command line flags

- `tls-cert-file` default value `/etc/ssl/tls.crt`
- `tls-private-key-file` default value `/etc/ssl/tls.key`
- `tls-client-auth-type` default value `NoClientCert`
- `tls-client-ca-file` default value empty
- `tls-min-version` default value TLS version 13
- `tls-enabled` default value false

In order to use the feature, one needs to give a flag `-tls-enabled=1`. The defaults are used and the existence of TLS key-files is checked and error is thrown if no files are found. The defaults can be changed by using the corresponding flags.

Fixes #14