### PR TITLE
Support configurable container engine (Docker/Podman)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,5 +40,9 @@ VERSION ?= $(shell git describe --tags --always --dirty)
 # Set to 1 to print more verbose output from the build.
 VERBOSE ?= 0
 
+# Container engine to use. Auto-detected: docker if available, otherwise podman.
+# Override explicitly: make CONTAINER_ENGINE=podman build
+CONTAINER_ENGINE ?= $(if $(shell command -v docker 2>/dev/null),docker,podman)
+
 # Include standard build rules.
 include rules.mk

--- a/README.md
+++ b/README.md
@@ -6,21 +6,22 @@ This is the repository for [Kubernetes Node-Local DNS Cache](https://kubernetes.
 
 `make` targets:
 
-| target | description |
-| ---- | ---- |
-|all, build   | build all binaries |
-|test         | run unit tests |
-|containers   | build the containers |
-|images-clean | clear image build artifacts from workdir |
-|push         | push containers to the registry |
-|help         | this help message |
-|version      | show package version |
-|{build,containers,push}-ARCH | do action for specific ARCH |
-|all-{build,containers,push}  | do action for all ARCH |
-|only-push-BINARY             | push just BINARY |
+| target                       | description                              |
+| ---------------------------- | ---------------------------------------- |
+| all, build                   | build all binaries                       |
+| test                         | run unit tests                           |
+| containers                   | build the containers                     |
+| images-clean                 | clear image build artifacts from workdir |
+| push                         | push containers to the registry          |
+| help                         | this help message                        |
+| version                      | show package version                     |
+| {build,containers,push}-ARCH | do action for specific ARCH              |
+| all-{build,containers,push}  | do action for all ARCH                   |
+| only-push-BINARY             | push just BINARY                         |
 
-* Setting `VERBOSE=1` will show additional build logging.
-* Setting `VERSION` will override the container version tag.
+- Setting `VERBOSE=1` will show additional build logging.
+- Setting `VERSION` will override the container version tag.
+- Settingn `CONTAINER_ENGINE=podman` will override the container engine. Automatically detected.
 
 ## Vulnerability patching
 
@@ -45,10 +46,11 @@ go mod vendor
 ```
 
 ## Release process
+
 Follow these steps to make changes and release a new binary.
 
 1. Make the necessary code changes and create a PR.
-2. Build and test locally (`make images-clean`; `make build`; `make containers`; `make test`). 
+2. Build and test locally (`make images-clean`; `make build`; `make containers`; `make test`).
 3. The same steps are executed via the presubmit script `presubmits.sh` which is run by the [test-infra prow job.](https://github.com/kubernetes/test-infra/blob/88cd2798f36010e071a30c9827f90e647b59fc65/config/jobs/kubernetes/sig-network/sig-network-misc.yaml#L182)
 4. Merge the PR.
 5. Cut a new release tag. We use [semantic versioning](http://semver.org) to
@@ -73,7 +75,7 @@ Follow these steps to make changes and release a new binary.
    version of the containers. Example - https://github.com/kubernetes/kubernetes/pull/106189.
    Trigger the optional [presubmit](https://github.com/kubernetes/test-infra/pull/33962) `pull-kubernetes-e2e-gci-gce-kube-dns-nodecache` and correct your PR if needed before merging.
 10. Verify the nodecache-related tabs of the test grid at https://testgrid.k8s.io/sig-network-gce for regressions caused by the new image and revert if needed.
-   
+
 ## Version compatibility
 
 There is no version compatibility requirements with Kubernetes releases. Version numbers in this repo are not related to Kubernetes versions.

--- a/build/build.sh
+++ b/build/build.sh
@@ -31,9 +31,17 @@ if [ -z "${VERSION}" ]; then
 fi
 
 export CGO_ENABLED=0
+export GOOS="linux"
 export GOARCH="${ARCH}"
-if [ $GOARCH == "amd64" ]; then
-    export GOBIN="$GOPATH/bin/linux_amd64"
+
+# On a native build (host arch == target arch) Go outputs to $GOPATH/bin/ by
+# default, so we redirect explicitly to match the volume-mount path used by
+# rules.mk. On a cross-compilation (e.g. arm64 host building for amd64) Go
+# already places binaries in $GOPATH/bin/linux_${GOARCH}/, so GOBIN must not
+# be set (Go rejects GOBIN during cross-compilation).
+GOHOSTARCH=$(go env GOHOSTARCH)
+if [ "${GOARCH}" == "${GOHOSTARCH}" ]; then
+    export GOBIN="$GOPATH/bin/linux_${GOARCH}"
 fi
 
 go install                                                         \

--- a/rules.mk
+++ b/rules.mk
@@ -24,6 +24,7 @@ export IMAGES
 export REGISTRY
 export VERBOSE
 export VERSION
+export CONTAINER_ENGINE
 
 # directories which hold app source (not vendored)
 SRC_DIRS := cmd pkg
@@ -40,8 +41,16 @@ IPTIMAGE ?= registry.k8s.io/build-image/distroless-iptables:v0.8.6@sha256:4e0a77
 CONTAINER_NAME  = $(REGISTRY)/$(CONTAINER_PREFIX)-$(BINARY)-$(ARCH)
 BUILDSTAMP_NAME = $(subst :,_,$(subst /,_,$(CONTAINER_NAME))_$(VERSION))
 
-# Ensure that the docker command line supports the manifest images
-export DOCKER_CLI_EXPERIMENTAL=enabled
+# buildx is a Docker plugin; Podman builds multi-platform images natively.
+# manifest push --purge (Docker) vs --rm (Podman) serve the same purpose.
+ifeq ($(CONTAINER_ENGINE),podman)
+  CONTAINER_BUILD_CMD      := $(CONTAINER_ENGINE) build
+  MANIFEST_PUSH_PURGE_FLAG := --rm
+else
+  CONTAINER_BUILD_CMD      := $(CONTAINER_ENGINE) buildx build
+  MANIFEST_PUSH_PURGE_FLAG := --purge
+  export DOCKER_CLI_EXPERIMENTAL=enabled
+endif
 
 ALL_BINARIES += $(BINARIES)
 ALL_BINARIES += $(CONTAINER_BINARIES)
@@ -82,10 +91,10 @@ all-push: $(addprefix push-, $(ALL_ARCH))
 	@for binary in $(CONTAINER_BINARIES); do \
 		MANIFEST_IMAGE=$(REGISTRY)/$(CONTAINER_PREFIX)-$${binary} ; \
 		for arch in $(ALL_ARCH); do \
-			docker manifest create --amend $$MANIFEST_IMAGE:$(VERSION) $$MANIFEST_IMAGE-$${arch}:${VERSION} ; \
-			docker manifest annotate --arch $${arch} $$MANIFEST_IMAGE:${VERSION} $$MANIFEST_IMAGE-$${arch}:${VERSION}; \
+			$(CONTAINER_ENGINE) manifest create --amend $$MANIFEST_IMAGE:$(VERSION) $$MANIFEST_IMAGE-$${arch}:${VERSION} ; \
+			$(CONTAINER_ENGINE) manifest annotate --arch $${arch} $$MANIFEST_IMAGE:${VERSION} $$MANIFEST_IMAGE-$${arch}:${VERSION}; \
 		done ; \
-		docker manifest push --purge $$MANIFEST_IMAGE:${VERSION} ; \
+		$(CONTAINER_ENGINE) manifest push $(MANIFEST_PUSH_PURGE_FLAG) $$MANIFEST_IMAGE:${VERSION} ; \
 	done
 
 .PHONY: build
@@ -101,8 +110,8 @@ build: $(GO_BINARIES)
 # So this is a workaround where we set GOCACHE env variable, but do not use it as a volume.
 $(GO_BINARIES): build-dirs
 	@echo "building : $@"
-	@docker pull $(BUILD_IMAGE)
-	@docker run                                                            \
+	@$(CONTAINER_ENGINE) pull $(BUILD_IMAGE)
+	@$(CONTAINER_ENGINE) run                                              \
 	    --rm                                                               \
 	    --sig-proxy=true                                                   \
 	    -u $$(id -u):$$(id -g)                                             \
@@ -142,14 +151,14 @@ $(foreach BINARY,$(CONTAINER_BINARIES),$(eval $(DOCKERFILE_RULE)))
 define CONTAINER_RULE
 .$(BUILDSTAMP_NAME)-container: bin/$(ARCH)/$(BINARY)
 	@echo "container: bin/$(ARCH)/$(BINARY) ($(CONTAINER_NAME))"
-	@docker buildx build					\
+	@$(CONTAINER_BUILD_CMD)					\
 		--platform linux/$(ARCH)			\
 		$(DOCKER_BUILD_FLAGS)				\
 		-t $(CONTAINER_NAME):$(VERSION)		\
 		-f .$(BINARY)-$(ARCH)-dockerfile .	\
 		$(VERBOSE_OUTPUT)
 	@echo "$(CONTAINER_NAME):$(VERSION)" > $$@
-	@docker images -q $(CONTAINER_NAME):$(VERSION) >> $$@
+	@$(CONTAINER_ENGINE) images -q $(CONTAINER_NAME):$(VERSION) >> $$@
 endef
 $(foreach BINARY,$(CONTAINER_BINARIES),$(eval $(CONTAINER_RULE)))
 
@@ -163,7 +172,7 @@ push: $(PUSH_BUILDSTAMPS)
 
 .%-push: .%-container
 	@echo "pushing  :" $$(head -n 1 $<)
-	@docker push $$(head -n 1 $<) $(VERBOSE_OUTPUT)
+	@$(CONTAINER_ENGINE) push $$(head -n 1 $<) $(VERBOSE_OUTPUT)
 	@cat $< > $@
 
 define PUSH_RULE
@@ -181,7 +190,7 @@ $(foreach BINARY,$(CONTAINER_BINARIES),$(eval $(PUSH_RULE)))
 # So this is a workaround where we set GOCACHE env variable, but do not use it as a volume.
 .PHONY: test
 test: build-dirs
-	@docker run                                                            \
+	@$(CONTAINER_ENGINE) run                                              \
 	    --rm                                                               \
 	    --sig-proxy=true                                                   \
 	    -u $$(id -u):$$(id -g)                                             \
@@ -238,3 +247,5 @@ help:
 	@echo "  Setting VERBOSE=1 will show additional build logging."
 	@echo
 	@echo "  Setting VERSION will override the container version tag."
+	@echo
+	@echo "  Setting CONTAINER_ENGINE=podman enables Podman instead of Docker."


### PR DESCRIPTION
Add support for podman builds

I mainly needed this to build and test on macOS where Podman is more convenient (IMO) than Docker Desktop. The container engine is now auto-detected (docker if available, podman otherwise), i think existing CI would be unaffected?

Also fixed an issue with cross-compiles

AI disclaimer: Claude was used
